### PR TITLE
Direct subcompose

### DIFF
--- a/crates/actuate-core/src/lib.rs
+++ b/crates/actuate-core/src/lib.rs
@@ -222,11 +222,11 @@ impl<T: ?Sized> Clone for Ref<'_, T> {
 
 impl<T: ?Sized> Copy for Ref<'_, T> {}
 
-impl<T: ?Sized> Deref for Ref<'_, T> {
-    type Target = T;
+impl<'a, T: ?Sized> Deref for Ref<'a, T> {
+    type Target = &'a T;
 
     fn deref(&self) -> &Self::Target {
-        self.value
+        &self.value
     }
 }
 

--- a/src/flex.rs
+++ b/src/flex.rs
@@ -50,6 +50,6 @@ impl<C: Compose> Compose for Flex<C> {
             *renderer_cx.parent_key.borrow_mut() = id;
         });
 
-        Ref::map(cx.me(), |me| &me.content)
+        &cx.me().content
     }
 }


### PR DESCRIPTION
Makes replacing `Ref::map(cx.me(), |me| &me.content)` with just `&cx.me().content` possible.