### PR TITLE
Add border radius view modifier

### DIFF
--- a/examples/counter.rs
+++ b/examples/counter.rs
@@ -15,10 +15,12 @@ impl Compose for Counter {
                 .font_size(60.),
             Text::new("Up high")
                 .on_click(move || Mut::update(count, |x| *x += 1))
-                .background_color(Color::BLUE),
+                .background_color(Color::BLUE)
+                .border_radius(8.),
             Text::new("Down low")
                 .on_click(move || Mut::update(count, |x| *x -= 1))
-                .background_color(Color::RED),
+                .background_color(Color::RED)
+                .border_radius(8.),
             if *count == 0 {
                 Some(Text::new("Gimme five!"))
             } else {

--- a/src/ui/view/mod.rs
+++ b/src/ui/view/mod.rs
@@ -73,6 +73,11 @@ pub trait View: Compose {
         self.modify(FontSize { font_size })
     }
 
+    /// Set the border radius for this view.
+    fn border_radius(self, border_radius: f64) -> Modified<BorderRadius, Self> {
+        self.modify(BorderRadius { border_radius })
+    }
+
     /// Add a drawable modifier to this view.
     fn draw<D: Draw + 'static>(self, draw: D) -> Modified<DrawModifier<D>, Self> {
         self.modify(DrawModifier::new(draw))
@@ -186,6 +191,7 @@ impl<H: Handler> Modify for OnEvent<H> {
             CanvasContext {
                 draws: canvas_cx.draws.clone(),
                 pending_listeners: Rc::new(RefCell::new(pending_listeners)),
+                border_radius: canvas_cx.border_radius,
             }
         });
     }
@@ -344,6 +350,25 @@ impl Modify for Font {
             color: text_cx.color,
             font_size: text_cx.font_size,
             font_stack: self.font_stack.clone(),
+        });
+    }
+}
+
+/// Border radius modifier.
+#[derive(Data)]
+pub struct BorderRadius {
+    /// Border radius.
+    pub border_radius: f64,
+}
+
+impl Modify for BorderRadius {
+    fn use_state<'a>(&'a self, cx: ScopeState<'a>) {
+        let canvas_cx = use_context::<CanvasContext>(cx).unwrap();
+
+        use_provider(cx, || CanvasContext {
+            draws: canvas_cx.draws.clone(),
+            pending_listeners: canvas_cx.pending_listeners.clone(),
+            border_radius: self.border_radius,
         });
     }
 }


### PR DESCRIPTION
Fixes #24.

I did not add it as a `impl Draw` because otherwise you'd have to make sure to process the border radius clipping before other modifiers, e.g. the background color.