### PR TITLE
fix: remove accidental tokio import in ecs.rs

### DIFF
--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -17,9 +17,8 @@ use std::{
     cell::{Cell, RefCell},
     mem, ptr,
     rc::Rc,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, RwLockWriteGuard},
 };
-use tokio::sync::RwLockWriteGuard;
 
 macro_rules! impl_trait_for_tuples {
     ($t:tt) => {

--- a/src/ecs.rs
+++ b/src/ecs.rs
@@ -17,7 +17,7 @@ use std::{
     cell::{Cell, RefCell},
     mem, ptr,
     rc::Rc,
-    sync::{Arc, Mutex, RwLockWriteGuard},
+    sync::{Arc, Mutex},
 };
 
 macro_rules! impl_trait_for_tuples {
@@ -41,7 +41,6 @@ impl Plugin for ActuatePlugin {
     fn build(&self, app: &mut App) {
         let rt = Runtime {
             composers: RefCell::new(HashMap::new()),
-            lock: None,
         };
 
         app.insert_non_send_resource(rt)
@@ -91,7 +90,6 @@ struct RuntimeComposer {
 
 struct Runtime {
     composers: RefCell<HashMap<Entity, RuntimeComposer>>,
-    lock: Option<RwLockWriteGuard<'static, ()>>,
 }
 
 /// Composition of some composable content.
@@ -179,9 +177,6 @@ impl<C: Compose> Compose for CompositionContent<C> {
 }
 
 fn compose(world: &mut World) {
-    let mut rt = world.non_send_resource_mut::<Runtime>();
-    rt.lock = None;
-
     RUNTIME_CONTEXT.with(|runtime_cx| {
         let mut cell = runtime_cx.borrow_mut();
         let runtime_cx = cell.get_or_insert_with(|| RuntimeContext {


### PR DESCRIPTION
Accidental import of tokio in the `ecs.rs` file forces you to enable the `rt` feature to compile.