### PR TITLE
feat!: store the composition as nodes in the runtime

### DIFF
--- a/examples/core/composer.rs
+++ b/examples/core/composer.rs
@@ -35,7 +35,7 @@ fn main() {
     .unwrap();
 
     let mut composer = Composer::new(App);
-    
+
     // Compose each composable.
     for _ in 0..3 {
         composer.try_compose().unwrap();

--- a/examples/core/composer.rs
+++ b/examples/core/composer.rs
@@ -36,10 +36,7 @@ fn main() {
 
     let mut composer = Composer::new(App);
 
-    // Compose each composable.
-    for _ in 0..3 {
-        composer.try_compose().unwrap();
-    }
+    composer.try_compose().unwrap();
 
     assert_eq!(composer.try_compose(), Err(TryComposeError::Pending));
 

--- a/examples/core/composer.rs
+++ b/examples/core/composer.rs
@@ -38,4 +38,6 @@ fn main() {
     composer.try_compose().unwrap();
 
     assert_eq!(composer.try_compose(), Err(TryComposeError::Pending));
+
+    dbg!(composer);
 }

--- a/examples/core/composer.rs
+++ b/examples/core/composer.rs
@@ -35,7 +35,11 @@ fn main() {
     .unwrap();
 
     let mut composer = Composer::new(App);
-    composer.try_compose().unwrap();
+    
+    // Compose each composable.
+    for _ in 0..3 {
+        composer.try_compose().unwrap();
+    }
 
     assert_eq!(composer.try_compose(), Err(TryComposeError::Pending));
 

--- a/src/compose/dyn_compose.rs
+++ b/src/compose/dyn_compose.rs
@@ -1,6 +1,12 @@
-use super::AnyCompose;
+use slotmap::DefaultKey;
+
+use super::{drop_node, AnyCompose, Node, Runtime};
 use crate::{compose::Compose, use_ref, Scope, ScopeData};
 use core::{any::TypeId, cell::UnsafeCell, mem};
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
 
 /// Create a new dynamically-typed composable.
 pub fn dyn_compose<'a>(content: impl Compose + 'a) -> DynCompose<'a> {
@@ -15,20 +21,64 @@ pub struct DynCompose<'a> {
     compose: UnsafeCell<Option<Box<dyn AnyCompose + 'a>>>,
 }
 
+#[derive(Clone, Copy)]
 struct DynComposeState {
-    compose: Box<dyn AnyCompose>,
+    key: DefaultKey,
     data_id: TypeId,
 }
 
 impl Compose for DynCompose<'_> {
     fn compose(cx: Scope<Self>) -> impl Compose {
-        let cell: &UnsafeCell<Option<DynComposeState>> = use_ref(&cx, || UnsafeCell::new(None));
-        let cell = unsafe { &mut *cell.get() };
+        let state: &Cell<Option<DynComposeState>> = use_ref(&cx, || Cell::new(None));
 
-        let inner = unsafe { &mut *cx.me().compose.get() };
+        let rt = Runtime::current();
+        let mut nodes = rt.nodes.borrow_mut();
 
-        let child_state = use_ref(&cx, || UnsafeCell::new(ScopeData::default()));
-        let child_state = unsafe { &mut *child_state.get() };
+        if let Some(state) = state.get() {
+            let compose: &mut dyn AnyCompose = unsafe { &mut *cx.me().compose.get() }
+                .as_deref_mut()
+                .unwrap();
+            let mut compose: Box<dyn AnyCompose> = unsafe { mem::transmute(compose) };
+            let data_id = compose.data_id();
+
+            if data_id == state.data_id {
+                let mut last = nodes[state.key].compose.borrow_mut();
+                unsafe { compose.reborrow(last.as_ptr_mut()) };
+
+                rt.pending.borrow_mut().push_back(state.key);
+
+                return;
+            } else {
+                drop_node(&mut nodes, state.key);
+            }
+        }
+
+        let Some(compose) = unsafe { &mut *cx.me().compose.get() }.take() else {
+            if let Some(state) = state.get() {
+                rt.pending.borrow_mut().push_back(state.key);
+            }
+
+            return;
+        };
+        let compose: Box<dyn AnyCompose> = unsafe { mem::transmute(compose) };
+        let data_id = compose.data_id();
+
+        let key = nodes.insert(Rc::new(Node {
+            compose: RefCell::new(crate::composer::ComposePtr::Boxed(compose)),
+            scope: ScopeData::default(),
+            parent: Some(rt.current_key.get()),
+            children: RefCell::new(Vec::new()),
+        }));
+        state.set(Some(DynComposeState { key, data_id }));
+
+        nodes
+            .get(rt.current_key.get())
+            .unwrap()
+            .children
+            .borrow_mut()
+            .push(key);
+
+        let child_state = &nodes[key].scope;
 
         *child_state.contexts.borrow_mut() = cx.contexts.borrow().clone();
         child_state
@@ -37,27 +87,6 @@ impl Compose for DynCompose<'_> {
             .values
             .extend(cx.child_contexts.borrow().values.clone());
 
-        if let Some(any_compose) = inner.take() {
-            let mut compose: Box<dyn AnyCompose> = unsafe { mem::transmute(any_compose) };
-
-            if let Some(state) = cell {
-                if state.data_id != compose.data_id() {
-                    *child_state = ScopeData::default();
-                    state.compose = compose;
-                } else {
-                    let ptr = (*state.compose).as_ptr_mut();
-                    unsafe {
-                        compose.reborrow(ptr);
-                    }
-                }
-            } else {
-                *cell = Some(DynComposeState {
-                    data_id: compose.data_id(),
-                    compose,
-                })
-            }
-        }
-
-        unsafe { cell.as_mut().unwrap().compose.any_compose(child_state) }
+        rt.pending.borrow_mut().push_back(key);
     }
 }

--- a/src/compose/dyn_compose.rs
+++ b/src/compose/dyn_compose.rs
@@ -22,8 +22,6 @@ struct DynComposeState {
 
 impl Compose for DynCompose<'_> {
     fn compose(cx: Scope<Self>) -> impl Compose {
-        cx.is_container.set(true);
-
         let cell: &UnsafeCell<Option<DynComposeState>> = use_ref(&cx, || UnsafeCell::new(None));
         let cell = unsafe { &mut *cell.get() };
 
@@ -38,10 +36,6 @@ impl Compose for DynCompose<'_> {
             .borrow_mut()
             .values
             .extend(cx.child_contexts.borrow().values.clone());
-
-        child_state
-            .is_parent_changed
-            .set(cx.is_parent_changed.get());
 
         if let Some(any_compose) = inner.take() {
             let mut compose: Box<dyn AnyCompose> = unsafe { mem::transmute(any_compose) };

--- a/src/compose/from_iter.rs
+++ b/src/compose/from_iter.rs
@@ -72,6 +72,7 @@ where
                 let key = nodes.insert(Rc::new(Node {
                     compose: RefCell::new(crate::composer::ComposePtr::Boxed(any_compose)),
                     scope: ScopeData::default(),
+                    parent: Some(rt.current_key.get()),
                     children: RefCell::new(Vec::new()),
                 }));
                 nodes

--- a/src/compose/memo.rs
+++ b/src/compose/memo.rs
@@ -1,6 +1,8 @@
-use crate::{compose::Compose, data::Data, use_ref, Scope, Signal};
+use super::{AnyCompose, Node, Runtime};
+use crate::{compose::Compose, data::Data, use_ref, Scope, ScopeData};
 use alloc::borrow::Cow;
 use core::cell::RefCell;
+use std::{mem, rc::Rc};
 
 /// Create a new memoized composable.
 ///
@@ -35,19 +37,66 @@ where
     C: Compose,
 {
     fn compose(cx: Scope<Self>) -> impl Compose {
+        /*
+        unsafe { Signal::map_unchecked(cx.me(), |me| &me.content) }
+        */
+
+        let rt = Runtime::current();
+
+        let mut is_init = false;
+
+        let child_key = use_ref(&cx, || {
+            is_init = true;
+
+            let mut nodes = rt.nodes.borrow_mut();
+
+            let ptr: *const dyn AnyCompose =
+                unsafe { mem::transmute(&cx.me().content as *const dyn AnyCompose) };
+            let child_key = nodes.insert(Rc::new(Node {
+                compose: RefCell::new(crate::composer::ComposePtr::Ptr(ptr)),
+                scope: ScopeData::default(),
+                children: RefCell::new(Vec::new()),
+            }));
+
+            nodes
+                .get(rt.current_key.get())
+                .unwrap()
+                .children
+                .borrow_mut()
+                .push(child_key);
+
+            let child_state = &nodes[child_key].scope;
+
+            *child_state.contexts.borrow_mut() = cx.contexts.borrow().clone();
+            child_state
+                .contexts
+                .borrow_mut()
+                .values
+                .extend(cx.child_contexts.borrow().values.clone());
+
+            child_state.is_parent_changed.set(true);
+
+            child_key
+        });
+
+        if !is_init {
+            let last = rt.nodes.borrow().get(*child_key).unwrap().clone();
+            let ptr: *const dyn AnyCompose =
+                unsafe { mem::transmute(&cx.me().content as *const dyn AnyCompose) };
+            *last.compose.borrow_mut() = crate::composer::ComposePtr::Ptr(ptr);
+        }
+
         let last = use_ref(&cx, RefCell::default);
         let mut last = last.borrow_mut();
         if let Some(last) = &mut *last {
             if cx.me().dependency != *last {
                 *last = cx.me().dependency.clone();
-                cx.is_parent_changed.set(true);
+                rt.pending.borrow_mut().push_back(*child_key);
             }
         } else {
             *last = Some(cx.me().dependency.clone());
-            cx.is_parent_changed.set(true);
+            rt.pending.borrow_mut().push_back(*child_key);
         }
-
-        unsafe { Signal::map_unchecked(cx.me(), |me| &me.content) }
     }
 
     fn name() -> Option<Cow<'static, str>> {

--- a/src/compose/memo.rs
+++ b/src/compose/memo.rs
@@ -37,14 +37,9 @@ where
     C: Compose,
 {
     fn compose(cx: Scope<Self>) -> impl Compose {
-        /*
-        unsafe { Signal::map_unchecked(cx.me(), |me| &me.content) }
-        */
-
         let rt = Runtime::current();
 
         let mut is_init = false;
-
         let child_key = use_ref(&cx, || {
             is_init = true;
 

--- a/src/compose/memo.rs
+++ b/src/compose/memo.rs
@@ -50,6 +50,7 @@ where
             let child_key = nodes.insert(Rc::new(Node {
                 compose: RefCell::new(crate::composer::ComposePtr::Ptr(ptr)),
                 scope: ScopeData::default(),
+                parent: Some(rt.current_key.get()),
                 children: RefCell::new(Vec::new()),
             }));
 

--- a/src/compose/memo.rs
+++ b/src/compose/memo.rs
@@ -74,8 +74,6 @@ where
                 .values
                 .extend(cx.child_contexts.borrow().values.clone());
 
-            child_state.is_parent_changed.set(true);
-
             child_key
         });
 

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -176,7 +176,11 @@ macro_rules! impl_tuples {
                 let rt = Runtime::current();
 
                 $(
+                    let mut is_init = false;
+
                     let child_key = use_ref(&cx, || {
+                        is_init = true;
+
                         let mut nodes = rt.nodes.borrow_mut();
 
                         let ptr = unsafe { mem::transmute(&cx.me().$idx as *const dyn AnyCompose) };
@@ -206,6 +210,12 @@ macro_rules! impl_tuples {
 
                         child_key
                     });
+
+                    if !is_init {
+                        let last = rt.nodes.borrow().get(*child_key).unwrap().clone();
+                        let ptr = unsafe { mem::transmute(&cx.me().$idx as *const dyn AnyCompose) };
+                        *last.compose.borrow_mut() = crate::composer::ComposePtr::Ptr(ptr);
+                    }
 
                     let node = rt.nodes.borrow().get(*child_key).unwrap().clone();
                     let compose: &dyn AnyCompose = &*node.compose.borrow();

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -131,8 +131,6 @@ fn drop_node(nodes: &mut SlotMap<DefaultKey, Rc<Node>>, key: DefaultKey) {
         parent.children.borrow_mut().retain(|&x| x != key);
     }
 
-    //Runtime::current().pending.borrow_mut().retain(|&x| x != key);
-
     let children = node.children.borrow().clone();
     for key in children {
         drop_node(nodes, key)

--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -364,7 +364,7 @@ where
                     child.reborrow(last.compose.borrow_mut().as_ptr_mut());
                 } else {
                     let child_key = nodes.insert(Rc::new(Node {
-                        compose: RefCell::new(crate::composer::ComposePtr::Owned(child)),
+                        compose: RefCell::new(crate::composer::ComposePtr::Boxed(child)),
                         scope: ScopeData::default(),
                         children: RefCell::new(Vec::new()),
                     }));

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -23,28 +23,28 @@ use tokio::sync::RwLock;
 type RuntimeFuture = Pin<Box<dyn Future<Output = ()>>>;
 
 pub(crate) enum ComposePtr {
-    Owned(Box<dyn AnyCompose>),
+    Boxed(Box<dyn AnyCompose>),
     Ptr(*const dyn AnyCompose),
 }
 
 impl AnyCompose for ComposePtr {
     fn data_id(&self) -> TypeId {
         match self {
-            ComposePtr::Owned(compose) => compose.data_id(),
+            ComposePtr::Boxed(compose) => compose.data_id(),
             ComposePtr::Ptr(ptr) => unsafe { (**ptr).data_id() },
         }
     }
 
     fn as_ptr_mut(&mut self) -> *mut () {
         match self {
-            ComposePtr::Owned(compose) => compose.as_ptr_mut(),
+            ComposePtr::Boxed(compose) => compose.as_ptr_mut(),
             ComposePtr::Ptr(ptr) => *ptr as *mut (),
         }
     }
 
     unsafe fn reborrow(&mut self, ptr: *mut ()) {
         match self {
-            ComposePtr::Owned(compose) => compose.reborrow(ptr),
+            ComposePtr::Boxed(compose) => compose.reborrow(ptr),
             // TODO
             ComposePtr::Ptr(_) => {}
         }
@@ -52,14 +52,14 @@ impl AnyCompose for ComposePtr {
 
     unsafe fn any_compose(&self, state: &ScopeData) {
         match self {
-            ComposePtr::Owned(compose) => compose.any_compose(state),
+            ComposePtr::Boxed(compose) => compose.any_compose(state),
             ComposePtr::Ptr(ptr) => (**ptr).any_compose(state),
         }
     }
 
     fn name(&self) -> Option<std::borrow::Cow<'static, str>> {
         match self {
-            ComposePtr::Owned(compose) => compose.name(),
+            ComposePtr::Boxed(compose) => compose.name(),
             ComposePtr::Ptr(_) => None,
         }
     }
@@ -192,7 +192,7 @@ impl Composer {
 
         let mut nodes = SlotMap::new();
         let root_key = nodes.insert(Rc::new(Node {
-            compose: RefCell::new(ComposePtr::Owned(Box::new(content))),
+            compose: RefCell::new(ComposePtr::Boxed(Box::new(content))),
             scope: ScopeData::default(),
             children: RefCell::new(Vec::new()),
         }));

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -175,7 +175,7 @@ impl Composer {
     pub fn try_compose(&mut self) -> Result<(), TryComposeError> {
         let mut is_pending = true;
 
-        while let Some(res) = self.next() {
+        for res in self.by_ref() {
             res.map_err(TryComposeError::Error)?;
 
             is_pending = false;

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -45,7 +45,6 @@ impl AnyCompose for ComposePtr {
     unsafe fn reborrow(&mut self, ptr: *mut ()) {
         match self {
             ComposePtr::Boxed(compose) => compose.reborrow(ptr),
-            // TODO
             ComposePtr::Ptr(_) => {}
         }
     }

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -9,6 +9,7 @@ use core::{
     error::Error,
     fmt,
     future::Future,
+    mem,
     pin::Pin,
     task::{Context, Poll, Waker},
 };
@@ -123,7 +124,7 @@ pub enum TryComposeError {
 
 impl PartialEq for TryComposeError {
     fn eq(&self, other: &Self) -> bool {
-        core::mem::discriminant(self) == core::mem::discriminant(other)
+        mem::discriminant(self) == mem::discriminant(other)
     }
 }
 
@@ -172,61 +173,19 @@ impl Composer {
 
     /// Try to immediately compose the content in this composer.
     pub fn try_compose(&mut self) -> Result<(), TryComposeError> {
-        self.rt.enter();
+        let mut is_pending = true;
 
-        let error_cell = Rc::new(Cell::new(None));
-        let error_cell_handle = error_cell.clone();
+        while let Some(res) = self.next() {
+            res.map_err(TryComposeError::Error)?;
 
-        let root = self.rt.nodes.borrow().get(self.rt.root).unwrap().clone();
-        root.scope.contexts.borrow_mut().values.insert(
-            TypeId::of::<CatchContext>(),
-            Rc::new(CatchContext::new(move |error| {
-                error_cell_handle.set(Some(error));
-            })),
-        );
-
-        if !self.is_initial {
-            while let Some(key) = self.task_queue.pop() {
-                let waker = Waker::from(Arc::new(TaskWaker {
-                    key,
-                    waker: self.rt.waker.borrow().clone(),
-                    queue: self.rt.task_queue.clone(),
-                }));
-                let mut cx = Context::from_waker(&waker);
-
-                let mut tasks = self.rt.tasks.borrow_mut();
-                let task = tasks.get_mut(key).unwrap();
-                let _ = task.as_mut().poll(&mut cx);
-            }
-
-            while let Some(mut update) = self.update_queue.pop() {
-                update();
-            }
-
-            let key_cell = self.rt.pending.borrow_mut().pop();
-            if let Some(key) = key_cell {
-                self.rt.current_key.set(key);
-
-                let node = self.rt.nodes.borrow().get(key).unwrap().clone();
-
-                // Safety: `self.compose` is guaranteed to live as long as `self.scope_state`.
-                unsafe { node.compose.borrow().any_compose(&node.scope) };
-            } else {
-                return Err(TryComposeError::Pending);
-            }
-        } else {
-            self.is_initial = false;
-
-            self.rt.current_key.set(self.rt.root);
-
-            // Safety: `self.compose` is guaranteed to live as long as `self.scope_state`.
-            unsafe { root.compose.borrow().any_compose(&root.scope) };
+            is_pending = false;
         }
 
-        error_cell
-            .take()
-            .map(|error| Err(TryComposeError::Error(error)))
-            .unwrap_or_else(|| Ok(()))
+        if is_pending {
+            Err(TryComposeError::Pending)
+        } else {
+            Ok(())
+        }
     }
 
     /// Poll a composition of the content in this composer.
@@ -243,6 +202,65 @@ impl Composer {
     /// Compose the content of this composer.
     pub async fn compose(&mut self) -> Result<(), Box<dyn Error>> {
         futures::future::poll_fn(|cx| self.poll_compose(cx)).await
+    }
+}
+
+impl Iterator for Composer {
+    type Item = Result<(), Box<dyn Error>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.rt.enter();
+
+        let error_cell = Rc::new(Cell::new(None));
+        let error_cell_handle = error_cell.clone();
+
+        let root = self.rt.nodes.borrow().get(self.rt.root).unwrap().clone();
+        root.scope.contexts.borrow_mut().values.insert(
+            TypeId::of::<CatchContext>(),
+            Rc::new(CatchContext::new(move |error| {
+                error_cell_handle.set(Some(error));
+            })),
+        );
+
+        if !self.is_initial {
+            let key_cell = self.rt.pending.borrow_mut().pop();
+            if let Some(key) = key_cell {
+                self.rt.current_key.set(key);
+
+                let node = self.rt.nodes.borrow().get(key).unwrap().clone();
+
+                // Safety: `self.compose` is guaranteed to live as long as `self.scope_state`.
+                unsafe { node.compose.borrow().any_compose(&node.scope) };
+            } else {
+                while let Some(key) = self.task_queue.pop() {
+                    let waker = Waker::from(Arc::new(TaskWaker {
+                        key,
+                        waker: self.rt.waker.borrow().clone(),
+                        queue: self.rt.task_queue.clone(),
+                    }));
+                    let mut cx = Context::from_waker(&waker);
+
+                    let mut tasks = self.rt.tasks.borrow_mut();
+                    let task = tasks.get_mut(key).unwrap();
+                    let _ = task.as_mut().poll(&mut cx);
+                }
+
+                while let Some(mut update) = self.update_queue.pop() {
+                    update();
+                }
+
+                return None;
+            }
+        } else {
+            self.is_initial = false;
+
+            self.rt.current_key.set(self.rt.root);
+
+            // Safety: `self.compose` is guaranteed to live as long as `self.scope_state`.
+            unsafe { root.compose.borrow().any_compose(&root.scope) };
+        }
+
+        Some(error_cell.take().map(Err).unwrap_or(Ok(())))
     }
 }
 
@@ -302,9 +320,10 @@ mod tests {
 
     impl Compose for Counter {
         fn compose(cx: Scope<Self>) -> impl Compose {
-            cx.me().x.set(cx.me().x.get() + 1);
+            let updater = use_mut(&cx, || ());
+            SignalMut::set(updater, ());
 
-            cx.set_changed();
+            cx.me().x.set(cx.me().x.get() + 1);
         }
     }
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -69,6 +69,7 @@ impl AnyCompose for ComposePtr {
 pub(crate) struct Node {
     pub(crate) compose: RefCell<ComposePtr>,
     pub(crate) scope: ScopeData<'static>,
+    pub(crate) parent: Option<DefaultKey>,
     pub(crate) children: RefCell<Vec<DefaultKey>>,
 }
 
@@ -194,6 +195,7 @@ impl Composer {
         let root_key = nodes.insert(Rc::new(Node {
             compose: RefCell::new(ComposePtr::Boxed(Box::new(content))),
             scope: ScopeData::default(),
+            parent: None,
             children: RefCell::new(Vec::new()),
         }));
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -13,9 +13,9 @@ use core::{
     pin::Pin,
     task::{Context, Poll, Waker},
 };
-use std::collections::VecDeque;
 use crossbeam_queue::SegQueue;
 use slotmap::{DefaultKey, SlotMap};
+use std::collections::VecDeque;
 
 #[cfg(feature = "executor")]
 use tokio::sync::RwLock;
@@ -74,7 +74,7 @@ pub(crate) struct Node {
 
 /// Runtime for a [`Composer`].
 #[derive(Clone)]
-pub struct Runtime {
+pub (crate) struct Runtime {
     /// Local task stored on this runtime.
     pub(crate) tasks: Rc<RefCell<SlotMap<DefaultKey, RuntimeFuture>>>,
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -13,6 +13,7 @@ use core::{
     pin::Pin,
     task::{Context, Poll, Waker},
 };
+use std::collections::VecDeque;
 use crossbeam_queue::SegQueue;
 use slotmap::{DefaultKey, SlotMap};
 
@@ -95,7 +96,7 @@ pub struct Runtime {
 
     pub(crate) root: DefaultKey,
 
-    pub(crate) pending: Rc<RefCell<Vec<DefaultKey>>>,
+    pub(crate) pending: Rc<RefCell<VecDeque<DefaultKey>>>,
 }
 
 impl Runtime {
@@ -207,7 +208,7 @@ impl Composer {
                 nodes: Rc::new(RefCell::new(nodes)),
                 current_key: Rc::new(Cell::new(root_key)),
                 root: root_key,
-                pending: Rc::new(RefCell::new(Vec::new())),
+                pending: Rc::new(RefCell::new(VecDeque::new())),
             },
             task_queue,
             update_queue,
@@ -284,7 +285,7 @@ impl Iterator for Composer {
         );
 
         if !self.is_initial {
-            let key_cell = self.rt.pending.borrow_mut().pop();
+            let key_cell = self.rt.pending.borrow_mut().pop_front();
             if let Some(key) = key_cell {
                 self.rt.current_key.set(key);
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -45,7 +45,7 @@ impl AnyCompose for ComposePtr {
         match self {
             ComposePtr::Owned(compose) => compose.reborrow(ptr),
             // TODO
-            ComposePtr::Ptr(_) => {},
+            ComposePtr::Ptr(_) => {}
         }
     }
 

--- a/src/composer.rs
+++ b/src/composer.rs
@@ -74,7 +74,7 @@ pub(crate) struct Node {
 
 /// Runtime for a [`Composer`].
 #[derive(Clone)]
-pub (crate) struct Runtime {
+pub(crate) struct Runtime {
     /// Local task stored on this runtime.
     pub(crate) tasks: Rc<RefCell<SlotMap<DefaultKey, RuntimeFuture>>>,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -321,22 +321,6 @@ impl<T: fmt::Display> fmt::Display for RefMap<'_, T> {
 
 unsafe impl<T: Data> Data for RefMap<'_, T> {}
 
-impl<C: Compose> Compose for RefMap<'_, C> {
-    fn compose(cx: Scope<Self>) -> impl Compose {
-        cx.is_container.set(true);
-
-        let state = use_ref(&cx, || {
-            let mut state = ScopeData::default();
-            state.contexts = cx.contexts.clone();
-            state
-        });
-
-        state.is_parent_changed.set(cx.is_parent_changed.get());
-
-        unsafe { (**cx.me()).any_compose(state) }
-    }
-}
-
 /// Mapped immutable reference to a value of type `T`.
 ///
 /// This can be created with [`Signal::map`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -464,7 +464,7 @@ impl<'a, T: 'static> SignalMut<'a, T> {
         let scope_key = me.scope_key;
 
         Self::with(me, move |value| {
-            Runtime::current().pending.borrow_mut().push(scope_key);
+            Runtime::current().pending.borrow_mut().push_back(scope_key);
 
             f(value)
         })


### PR DESCRIPTION
- [x] Store the composition as nodes in the runtime
- [x] Impl `Iterator` for `Composer` to step through re-compositions
- [x] Drop composables in reverse order to simulate the original behavior
- [x] Skip directly to composables with a pending queue
- [x] Make `Runtime` struct private
- [x] Update composables:
   - [x] `Memo`
   - [x] `(T1..T8)`
   - [x] `Option`
   - [x] `Result`
   - [x] `FromIter`
   - [x] `DynCompose`