### PR TITLE
Implement `Compose` for `Vec<C>`

### DIFF
--- a/src/compose/mod.rs
+++ b/src/compose/mod.rs
@@ -286,6 +286,22 @@ impl_tuples!(T1:0, T2:1, T3:2, T4:3, T5:4, T6:5);
 impl_tuples!(T1:0, T2:1, T3:2, T4:3, T5:4, T6:5, T7:6);
 impl_tuples!(T1:0, T2:1, T3:2, T4:3, T5:4, T6:5, T7:6, T8:7);
 
+impl<C> Compose for Vec<C>
+where
+    C: Compose,
+{
+    fn compose(cx: Scope<Self>) -> impl Compose {
+        for (idx, item) in cx.me().iter().enumerate() {
+            let ptr: *const dyn AnyCompose =
+                unsafe { mem::transmute(item as *const dyn AnyCompose) };
+            let (key, _) = use_node(&cx, ComposePtr::Ptr(ptr), idx);
+
+            let rt = Runtime::current();
+            rt.queue(key);
+        }
+    }
+}
+
 fn use_node(cx: ScopeState, compose_ptr: ComposePtr, child_idx: usize) -> (DefaultKey, &Rc<Node>) {
     let mut compose_ptr_cell = Some(compose_ptr);
 


### PR DESCRIPTION
I've stumbled into an issue where `from_iter` doesn't update the final compose result/ui when one of the elements in the Iterator changes. Perhaps it is working as intended or is just a bug ([issue](https://github.com/actuate-rs/actuate/issues/118)). In any case, implementing `Compose` for `Vec<C>` is a workaround for my issue, as well as being a reasonable implementation in general, in my opinion. Another benefit over using `from_iter` is that `from_iter` requires the iterator to implement Data + Clone, while this method does not.

Now, you could do something like this:

```rust
#[derive(Data)]
pub struct Something;

impl Compose for Something {
    fn compose(cx: Scope<Self>) -> impl Compose {
        let numbers = [20, 42, 39];

        numbers
            .iter()
            .map(|number| spawn(Text::new(number.to_string())))
            .collect::<Vec<_>>()
    }
}
```